### PR TITLE
Fixed white value

### DIFF
--- a/tools/Inky-pHAT.gpl
+++ b/tools/Inky-pHAT.gpl
@@ -2,6 +2,6 @@ GIMP Palette
 Name: Inky pHAT
 Columns: 1
 #
-254 255 255	Untitled
+255 255 255	Untitled
   0   0   0	Untitled
 255   0   0	Untitled


### PR DESCRIPTION
Formerly #feffff, now #ffffff

Author's comment is noted: “[Inky pHAT doesn't really care what colours are actually in the palette, since it operates by index only and irrespective of what colour is where it will always treat 0 as white, 1 as black and 2 as red](https://github.com/pimoroni/inky-phat/issues/7#issuecomment-316001856)”