### PR TITLE
Arbitrary Rotation

### DIFF
--- a/library/inkyphat/__init__.py
+++ b/library/inkyphat/__init__.py
@@ -72,12 +72,8 @@ def set_rotation(r):
     :param r: Rotation in degrees, can be either 0 or 180
 
     """
-    if r == 180:
-        _panel.h_flip = True
-        _panel.v_flip = False
-    else:
-        _panel.h_flip = False
-        _panel.v_flip = True
+    r = r % 360
+    _panel.set_image(_panel.get_image().rotate(r))
 
 def set_border(col):
     """Set panel border colour.

--- a/library/inkyphat/__init__.py
+++ b/library/inkyphat/__init__.py
@@ -73,7 +73,7 @@ def set_rotation(r):
 
     """
     r = r % 360
-    _panel.set_image(_panel.get_image().rotate(r))
+    set_image(get_image().rotate(r))
 
 def set_border(col):
     """Set panel border colour.


### PR DESCRIPTION
`PIL` already provides more than two methods of rotation so I'm unsure why `numpy` and the simple logic-check was used instead of in-built functionality. 

Fixes #15 