### PR TITLE
Fix colour handling for V1

### DIFF
--- a/examples/cal-ics.py
+++ b/examples/cal-ics.py
@@ -35,7 +35,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 CALENDAR_FILE = "resources/test.ics"
 

--- a/examples/cal-ics.py
+++ b/examples/cal-ics.py
@@ -30,7 +30,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 CALENDAR_FILE = "resources/test.ics"
 

--- a/examples/cal.py
+++ b/examples/cal.py
@@ -31,7 +31,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 inkyphat.set_border(inkyphat.BLACK)
 #inkyphat.set_rotation(180)

--- a/examples/cal.py
+++ b/examples/cal.py
@@ -26,7 +26,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 inkyphat.set_border(inkyphat.BLACK)
 #inkyphat.set_rotation(180)

--- a/examples/clean.py
+++ b/examples/clean.py
@@ -19,7 +19,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1].lower()
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 if len(sys.argv) > 2:
     cycles = int(sys.argv[2])

--- a/examples/clean.py
+++ b/examples/clean.py
@@ -24,7 +24,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 if len(sys.argv) > 2:
     cycles = int(sys.argv[2])

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -29,8 +29,10 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(sys.argv[2], inkyphat.get_version()))
-    print(USAGE)
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        print(USAGE)
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 # Show the backdrop image
 

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -19,7 +19,7 @@ USAGE = """Usage: {} "<your name>" <colour>
        Inky pHAT v1 is only available in red.
 """.format(sys.argv[0])
 
-if len(sys.argv) < 3 and inkyphat.get_version() == 2:
+if len(sys.argv) < 3:
     print(USAGE)
     sys.exit(1)
 

--- a/examples/hello.py
+++ b/examples/hello.py
@@ -14,15 +14,23 @@ Use Inky pHAT as a personalised name badge!
 
 #inkyphat.set_rotation(180)
 
-if len(sys.argv) < 3:
-    print("""Usage: {} <your name> <colour>
+USAGE = """Usage: {} "<your name>" <colour>
        Valid colours for v2 are: red, yellow or black
        Inky pHAT v1 is only available in red.
-""".format(sys.argv[0]))
+""".format(sys.argv[0])
+
+if len(sys.argv) < 3 and inkyphat.get_version() == 2:
+    print(USAGE)
     sys.exit(1)
 
 colour = sys.argv[2]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(sys.argv[2], inkyphat.get_version()))
+    print(USAGE)
+    sys.exit(1)
 
 # Show the backdrop image
 

--- a/examples/list-ics.py
+++ b/examples/list-ics.py
@@ -25,7 +25,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 CALENDAR_FILE = "resources/test.ics"
 

--- a/examples/list-ics.py
+++ b/examples/list-ics.py
@@ -30,7 +30,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 CALENDAR_FILE = "resources/test.ics"
 

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -23,7 +23,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 inkyphat.set_border(inkyphat.BLACK)
 

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -5,8 +5,6 @@ import sys
 
 import inkyphat
 
-inkyphat.set_colour('yellow')
-
 print("""Inky pHAT: Logo
 
 Displays the Inky pHAT logo.
@@ -20,7 +18,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1].lower()
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 inkyphat.set_border(inkyphat.BLACK)
 

--- a/examples/qr.py
+++ b/examples/qr.py
@@ -28,7 +28,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 if len(sys.argv) > 2:
     text = sys.argv[2]

--- a/examples/qr.py
+++ b/examples/qr.py
@@ -23,7 +23,12 @@ Inky pHAT v1 is only available in red.""".format(sys.argv[0]))
     sys.exit(1)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 if len(sys.argv) > 2:
     text = sys.argv[2]

--- a/examples/test.py
+++ b/examples/test.py
@@ -12,7 +12,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 font_file = inkyphat.fonts.FredokaOne
 inkyphat.arc((0, 0, 212, 104), 0, 180, 2)

--- a/examples/test.py
+++ b/examples/test.py
@@ -17,7 +17,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 font_file = inkyphat.fonts.FredokaOne
 inkyphat.arc((0, 0, 212, 104), 0, 180, 2)

--- a/examples/weather.py
+++ b/examples/weather.py
@@ -29,7 +29,12 @@ if len(sys.argv) < 2:
     sys.exit(0)
 
 colour = sys.argv[1]
-inkyphat.set_colour(colour)
+
+try:
+    inkyphat.set_colour(colour)
+except ValueError:
+    print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
+    sys.exit(1)
 
 inkyphat.set_border(inkyphat.BLACK)
 

--- a/examples/weather.py
+++ b/examples/weather.py
@@ -34,7 +34,9 @@ try:
     inkyphat.set_colour(colour)
 except ValueError:
     print('Invalid colour "{}" for V{}\n'.format(colour, inkyphat.get_version()))
-    sys.exit(1)
+    if inkyphat.get_version() == 2:
+        sys.exit(1)
+    print('Defaulting to "red"')
 
 inkyphat.set_border(inkyphat.BLACK)
 

--- a/library/inkyphat/inky212x104.py
+++ b/library/inkyphat/inky212x104.py
@@ -114,7 +114,9 @@ class Inky212x104:
         atexit.register(self._display_exit)
 
     def set_colour(self, colour):
-        if self.inky_version == 1:
+        colour = colour.lower()
+
+        if self.inky_version == 1 and not colour == 'red':
             raise ValueError("V1 is only available in Red")
 
         if colour not in ('red', 'black', 'yellow'):

--- a/library/inkyphat/inky212x104.py
+++ b/library/inkyphat/inky212x104.py
@@ -116,7 +116,9 @@ class Inky212x104:
     def set_colour(self, colour):
         colour = colour.lower()
 
-        if self.inky_version == 1 and not colour == 'red':
+        if self.inky_version == 1:
+            if colour == 'red':
+                return
             raise ValueError("V1 is only available in Red")
 
         if colour not in ('red', 'black', 'yellow'):


### PR DESCRIPTION
This prevents `set_colour` from throwing an error if you try to set a V1 Inky pHAT to red.

It also converts all V1 `set_colour` errors in examples to soft-failures (catching the error) and continuing in red.

Additionally it will warn about the colour it believes you asked for in case of failure- so that beginners can better understand what's going awry and fix their parameter order.

This should fix #19 